### PR TITLE
Add libp2p spec header

### DIFF
--- a/1A-tor-address-encoding-and-encrypted-peer-info.md
+++ b/1A-tor-address-encoding-and-encrypted-peer-info.md
@@ -1,6 +1,20 @@
-1A – Working Draft / Active
+# Tor Address Encoding and Encrypted `PeerInfo`
 
-Tor Address Encoding and Encrypted `PeerInfo`
+| Lifecycle Stage | Maturity      | Status | Latest Revision   |
+|-----------------|---------------|--------|-------------------|
+| 1A              | Working Draft | Active | DRAFT, 2019-05-31 |
+
+Authors: [@Zolmeister]
+
+Interest Group: [@yusefnapora], others TBD
+
+[@Zolmeister]: https://github.com/Zolmeister
+[@yusefnapora]: https://github.com/yusefnapora
+
+See the [lifecycle document][lifecycle-spec] for context about maturity level
+and spec status.
+
+[lifecycle-spec]: https://github.com/libp2p/specs/blob/master/00-framework-01-spec-lifecycle.md
 
 ### Context:
 


### PR DESCRIPTION
Hey @Zolmeister I figured I'd make a PR against your branch, so you can pull in the new libp2p spec header [we've been working on](https://github.com/libp2p/specs/pull/171) - that PR isn't final yet, but it seems likely it'll be close to what's in here.

Merging this PR to your fork should update https://github.com/libp2p/specs/pull/172 automatically.